### PR TITLE
Add .gitattributes for markdown language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.md linguist-documentation=false
+*.md linguist-detectable


### PR DESCRIPTION
See https://github.com/ggorlen/awesome-canvas which has "Markdown 100.0%" on the sidebar. This makes it a bit easier to identify the repository as text/documentation rather than having no language listed.