### PR TITLE
Add DXcharts Lite to canvas libraries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/r
 - [Chart.js](https://github.com/chartjs/Chart.js) is a lightweight JavaScript library for creating dynamic and visually appealing charts using the HTML5 Canvas element.
 - [ChemDoodle](http://web.chemdoodle.com/) is an open source chemistry and chem-informatics toolkit where canvas is being used to solve common chemistry related tasks, displaying the molecules in a variety of different ways.
 - [d3](https://github.com/d3/d3) (or D3.js) is a JavaScript library for visualizing data using web standards. D3 helps you bring data to life using SVG, Canvas and HTML.
+- [DXcharts Lite](https://github.com/devexperts/dxcharts-lite) is a canvas-based financial charting library with 100+ technical indicators, built for high-volume trading applications.
 - [EaselJS](https://createjs.com/easeljs) is a JavaScript library that makes working with the HTML5 Canvas element easy. Useful for creating games, generative art, and other highly graphical experiences. EaselJS is part of CreateJS - a modular libraries and tools which work together or independently to enable rich interactive content on open web technologies via HTML5.
 - [fabric.js](http://fabricjs.com) provides interactive object model on top of canvas element
 and also has SVG-to-canvas (and canvas-to-SVG) parser


### PR DESCRIPTION
DXcharts Lite is a free, canvas-based charting library built for trading/financial UIs (candlesticks, volumes, drawings, 100+ indicators). Adding it next to d3 since it's another canvas library for building visualizations.